### PR TITLE
Add `predictive` color for GitHub copilot predictions

### DIFF
--- a/themes/dark-default.json
+++ b/themes/dark-default.json
@@ -120,7 +120,7 @@
         "modified": "#58a6ff",
         "modified.background": null,
         "modified.border": null,
-        "predictive": null,
+        "predictive": "#7d8590",
         "predictive.background": null,
         "predictive.border": null,
         "renamed": null,


### PR DESCRIPTION
Just adds a predictive color used for GitHub Copilot to more easily distinguish suggestions from actual code.


| Before | After |
|--------|--------|
| <img width="1124" alt="Screenshot 2024-03-09 at 19 40 26" src="https://github.com/MordFustang21/zed-github-dark/assets/7325396/82bb83bc-ae2a-4eca-a40f-29e8bfcc6a58"> | <img width="1124" alt="Screenshot 2024-03-09 at 19 40 30" src="https://github.com/MordFustang21/zed-github-dark/assets/7325396/f217c480-5dde-49bc-82e9-547e3120383c"> |



