### PR TITLE
Add `warning` colors to fix hard to read warnings

### DIFF
--- a/themes/dark-default.json
+++ b/themes/dark-default.json
@@ -132,7 +132,7 @@
         "unreachable": null,
         "unreachable.background": null,
         "unreachable.border": null,
-        "warning": "#cc534e",
+        "warning": "#fbe557",
         "warning.background": "#161b22",
         "warning.border": "#30363d",
         "players": [],

--- a/themes/dark-default.json
+++ b/themes/dark-default.json
@@ -132,9 +132,9 @@
         "unreachable": null,
         "unreachable.background": null,
         "unreachable.border": null,
-        "warning": null,
-        "warning.background": null,
-        "warning.border": null,
+        "warning": "#cc534e",
+        "warning.background": "#161b22",
+        "warning.border": "#30363d",
         "players": [],
         "syntax": {
           "comment": {


### PR DESCRIPTION
This MR adds colors for the warnings to make warnings easier to read.


| **Before**  | **After** |
| ------------- | ------------- |
| ![Screenshot 2024-05-03 at 11 16 42](https://github.com/MordFustang21/zed-github-dark/assets/10487779/a985beb1-e6c3-49de-9881-059bb950611f) | ![Screenshot 2024-05-06 at 10 52 18](https://github.com/MordFustang21/zed-github-dark/assets/10487779/61ddec95-bb15-457d-8115-2c7633466262) |

Fix #1