### PR TITLE
Fix: boolean text color

### DIFF
--- a/themes/dark-default.json
+++ b/themes/dark-default.json
@@ -137,6 +137,11 @@
         "warning.border": "#30363d",
         "players": [],
         "syntax": {
+	  "boolean": {
+	    "color": "#79c0ff",
+	    "font_style": null,
+	    "font_weight": null
+	  },
           "comment": {
             "color": "#8b949e",
             "font_style": null,


### PR DESCRIPTION
| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/057760a7-863c-4f49-bc33-9af0467f6da5) | ![image](https://github.com/user-attachments/assets/2657004a-7b8a-43de-ab00-d71155c01d29)  |
