### PR TITLE
Fix problem with GitHub copilot suggestions between brackets and quotation marks

### DIFF
--- a/themes/dark-default.json
+++ b/themes/dark-default.json
@@ -62,7 +62,7 @@
         "editor.invisible": null,
         "editor.wrap_guide": "#30363d",
         "editor.active_wrap_guide": "#30363d",
-        "editor.document_highlight.read_background": null,
+        "editor.document_highlight.read_background": "#6e76811a",
         "editor.document_highlight.write_background": null,
         "editor.indent_guide": "#2f3337ff",
         "editor.indent_guide_active": "#666870ff",


### PR DESCRIPTION
## Fix problem with GitHub copilot suggestions between brackets and quotation marks

before:
![Screenshot from 2024-11-11 08-36-01](https://github.com/user-attachments/assets/724f3b10-cef5-4c80-bb55-e42be58109e9)

after:
![Screenshot from 2024-11-11 08-36-30](https://github.com/user-attachments/assets/7d1f0739-9752-4881-ab6c-8ace49cc0c12)
